### PR TITLE
Fix ad detection

### DIFF
--- a/src/spotishush.js
+++ b/src/spotishush.js
@@ -63,7 +63,7 @@
     const mo = new MutationObserver(async (mutations) => {
       SpotiShush.debug('mutations:', mutations)
 
-      if (footerObj.getAttribute('data-testid') === 'now-playing-bar-ad-type-ad') {
+      if (footerObj.getAttribute('data-testadtype') !== 'ad-type-none') {
         // This is an ad. Here's the simplified HTML snippet:
         //
         // <div class="...-scss ellipsis-one-line ...-scss" data-testid="track-info-name" as="div" dir="auto">


### PR DESCRIPTION
Changes Spotify ad detection to use newly added data attribute. Fixes #18 

Attribute 'data-testid' was split into 'data-testid' ('now-playing-bar' during both playback and ads) and 'data-testadtype' ('ad-type-none' during playback, 'ad-type-ad' during ad).

Tested locally on Chrome.