### PR TITLE
[Deezer] Ad detection changes

### DIFF
--- a/src/spotishush.js
+++ b/src/spotishush.js
@@ -70,9 +70,9 @@ function receiveFromBg (response) {
 
 async function deezerInit () {
   LOG('Waiting for ad control element to load...')
-  // This <div> (with no attributes) is inside the first <div> (also with no attributes) in #page_content.
+  // This <div> (with [id] attribute) is inside the first <div> (with no attributes) in #page_content and will be replaced with the HTMLAudioElement later.
   // The selector is purposely specific because this <div> is lazy-loaded, which can give us wrong matches.
-  const adControlElement = await lazySelector('#page_content > div:not([class], [id], [style]):nth-child(1) > div:not([class], [id], [style])')
+  const adControlElement = await lazySelector('#page_content > div:not([class], [id], [style])')
   deezerSetupAdsObserver(adControlElement)
   LOG('Monitoring ads now!')
 }


### PR DESCRIPTION
I don't know exactly what this part looked like on deezer before but the second (child) div seems to have a new id attribute added. This div will be replaced with the HTMLAudioElement ad later. Therefore the child selector is no longer working with addedNodes.

After page reload:
![Screenshot 2023-10-06 215106](https://github.com/guihkx/spotishush/assets/26782707/488a14c2-353e-442c-83f2-2e96ba3e90fd)
While playing ad:
![Screenshot 2023-10-06 215145](https://github.com/guihkx/spotishush/assets/26782707/c643ae01-6d70-42e0-8294-a2d2370a518e)

I tested it with some ads and page reloads and it still seems reliable.